### PR TITLE
Add pytest to Python for ML packages

### DIFF
--- a/extra/Dockerfile
+++ b/extra/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
         numpy \
         pandas \
         scikit-learn \
+        pytest \
         scipy && \
     rm -rf /var/lib/apt/lists/*
 

--- a/extra/tests/python3-for-ml/script.py
+++ b/extra/tests/python3-for-ml/script.py
@@ -1,6 +1,7 @@
 import mlxtend
 import numpy
 import pandas
+import pytest
 import scipy
 import sklearn
 


### PR DESCRIPTION
This pull request adds `pytest` to the Python for ML python packages.